### PR TITLE
Remove spaces from topics

### DIFF
--- a/src/Commands/CheckRssCommand.php
+++ b/src/Commands/CheckRssCommand.php
@@ -65,7 +65,7 @@ class CheckRssCommand extends Command
 
             if (count($item->get_categories())) {
                 foreach($item->get_categories() as $category) {
-                    $tags[] = sprintf("#%s", $category->get_term());
+                    $tags[] = sprintf("#%s", preg_replace("/\s*/", "", $category->get_term()));
                 }
             }
 


### PR DESCRIPTION
Remove spaces from topics because that have been creating confusing situation about hashtags
